### PR TITLE
ci: gate Docker push by tag and fix duplicate runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,14 @@ name: ci
 
 on:
   push:
-    branches: master
+    branches:
+      - master
+    tags:
+      - 'v*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   path-context:
@@ -34,6 +41,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
+        if: github.ref_type == 'tag'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -45,7 +53,7 @@ jobs:
           context: ./gateway-service
           file: ./gateway-service/Dockerfile.debug
           platforms: linux/amd64
-          push: true
+          push: ${{ github.ref_type == 'tag' }}
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/gateway-debug:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -56,7 +64,7 @@ jobs:
           context: ./employee-service
           file: ./employee-service/Dockerfile.debug
           platforms: linux/amd64
-          push: true
+          push: ${{ github.ref_type == 'tag' }}
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/employee-debug:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -67,7 +75,7 @@ jobs:
           context: ./organization-service
           file: ./organization-service/Dockerfile.debug
           platforms: linux/amd64
-          push: true
+          push: ${{ github.ref_type == 'tag' }}
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/organization-debug:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -78,7 +86,7 @@ jobs:
           context: ./department-service
           file: ./department-service/Dockerfile.debug
           platforms: linux/amd64
-          push: true
+          push: ${{ github.ref_type == 'tag' }}
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/department-debug:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Add tags: [v*] to push trigger
- Add concurrency group to cancel superseded runs
- Gate Docker login/push by tag

## Test plan
- [ ] Verify branch push skips Docker push
- [ ] Verify tag push triggers Docker push