### PR TITLE
fix(integration-test): activate Failsafe + set Accept header on @HttpExchange clients

### DIFF
--- a/department-service/pom.xml
+++ b/department-service/pom.xml
@@ -266,6 +266,16 @@
 					<argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
 				</configuration>
 			</plugin>
+			<!-- Bare reference activates Failsafe from parent POM's <pluginManagement>.
+			     Config (includes=**/*IT.java, argLine=@{argLine}) and execution bindings
+			     (integration-test + verify goals from the `integration-test` profile) are
+			     inherited. Without this reference, the profile's <build><plugins> entry
+			     applies only to the parent POM, not to this child — so Failsafe never runs
+			     here and `**/target/failsafe-reports/` stays empty. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/department-service/src/main/java/vmware/services/department/client/EmployeeClient.java
+++ b/department-service/src/main/java/vmware/services/department/client/EmployeeClient.java
@@ -7,6 +7,6 @@ import vmware.services.department.model.Employee;
 
 public interface EmployeeClient {
 
-  @GetExchange("/department/{departmentId}")
+  @GetExchange(value = "/department/{departmentId}", accept = "application/json")
   List<Employee> findByDepartment(@PathVariable("departmentId") String departmentId);
 }

--- a/employee-service/pom.xml
+++ b/employee-service/pom.xml
@@ -253,6 +253,16 @@
 					<argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
 				</configuration>
 			</plugin>
+			<!-- Bare reference activates Failsafe from parent POM's <pluginManagement>.
+			     Config (includes=**/*IT.java, argLine=@{argLine}) and execution bindings
+			     (integration-test + verify goals from the `integration-test` profile) are
+			     inherited. Without this reference, the profile's <build><plugins> entry
+			     applies only to the parent POM, not to this child — so Failsafe never runs
+			     here and `**/target/failsafe-reports/` stays empty. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/organization-service/pom.xml
+++ b/organization-service/pom.xml
@@ -264,7 +264,17 @@
 					<argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
 				</configuration>
 			</plugin>
+			<!-- Bare reference activates Failsafe from parent POM's <pluginManagement>.
+			     Config (includes=**/*IT.java, argLine=@{argLine}) and execution bindings
+			     (integration-test + verify goals from the `integration-test` profile) are
+			     inherited. Without this reference, the profile's <build><plugins> entry
+			     applies only to the parent POM, not to this child — so Failsafe never runs
+			     here and `**/target/failsafe-reports/` stays empty. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
-	
+
 </project>

--- a/organization-service/src/main/java/vmware/services/organization/client/DepartmentClient.java
+++ b/organization-service/src/main/java/vmware/services/organization/client/DepartmentClient.java
@@ -7,10 +7,10 @@ import vmware.services.organization.model.Department;
 
 public interface DepartmentClient {
 
-  @GetExchange("/organization/{organizationId}")
+  @GetExchange(value = "/organization/{organizationId}", accept = "application/json")
   List<Department> findByOrganization(@PathVariable("organizationId") String organizationId);
 
-  @GetExchange("/organization/{organizationId}/with-employees")
+  @GetExchange(value = "/organization/{organizationId}/with-employees", accept = "application/json")
   List<Department> findByOrganizationWithEmployees(
       @PathVariable("organizationId") String organizationId);
 }

--- a/organization-service/src/main/java/vmware/services/organization/client/EmployeeClient.java
+++ b/organization-service/src/main/java/vmware/services/organization/client/EmployeeClient.java
@@ -7,6 +7,6 @@ import vmware.services.organization.model.Employee;
 
 public interface EmployeeClient {
 
-  @GetExchange("/organization/{organizationId}")
+  @GetExchange(value = "/organization/{organizationId}", accept = "application/json")
   List<Employee> findByOrganization(@PathVariable("organizationId") String organizationId);
 }


### PR DESCRIPTION
## Summary

Two latent bugs that were hiding each other:

### 1. Failsafe never ran on service modules
The `integration-test` Maven profile defines Failsafe execution bindings inside `<profile><build><plugins>` at the parent POM. That block only applies to the parent POM's own build — children don't inherit active profile plugin additions automatically; they only inherit `<pluginManagement>`.

**Effect**: `mvn verify -P integration-test` fired Failsafe **only** on the aggregator parent (packaging=pom, no source → "No tests to run"), and every `*IT.java` file under employee-service / department-service / organization-service sat unexecuted. CI's "Upload Failsafe reports" step saw empty `**/target/failsafe-reports/` globs and emitted `##[warning]No files were found` on every push since the integration-test job was added.

**Fix**: bare Failsafe `<plugin>` reference in each IT-containing service's `<build><plugins>` — picks up parent `<pluginManagement>` config (includes=`**/*IT.java`, argLine=`@{argLine}`) and profile-supplied execution bindings.

### 2. @HttpExchange clients weren't setting Accept: application/json
Surfaced by fix #1. `DepartmentWithEmployeesIT` and the 3 `Organization*IT` classes verify outgoing RestClient calls include `Accept: application/json`, which Spring's `@GetExchange` does NOT set by default. These assertions were written but never validated.

**Fix**: add `accept = "application/json"` to `@GetExchange` on all 3 HTTP-interface clients:
- `department-service`: `EmployeeClient.findByDepartment`
- `organization-service`: `EmployeeClient.findByOrganization`
- `organization-service`: `DepartmentClient.findByOrganization` + `findByOrganizationWithEmployees`

This is the correct HTTP semantic — a JSON-consuming client should advertise that it accepts JSON.

## Verification

`make integration-test` locally now runs 14 IT tests across 3 services, all pass:
- 4 Employee IT
- 4 Department IT (3 Repository + 1 WithEmployees — previously 0 ran)
- 6 Organization IT (3 Repository + WithEmployees + WithDepartments + DeepFanOut — previously 0 ran)

Failsafe reports land under `**/target/failsafe-reports/` so the CI "Upload Failsafe reports" step now finds artifacts.

## Test plan

- [ ] CI passes (static-check + build + **integration-test now actually exercising IT layer**)
- [ ] `##[warning]No files were found` annotation on integration-test job disappears
- [ ] Failsafe reports artifact uploads successfully (visible in run summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)