### PR TITLE
chore: remove stale MetalLB references from Makefile + ci.yml comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,8 +341,9 @@ jobs:
   # End-to-end test job (mandatory per /ci-workflow).
   # Runs `make e2e` which cycles: kind-create → kind-setup (MongoDB) →
   # kind-deploy (build+load images) → e2e-test script → kind-destroy.
-  # Skipped under local act runs — nested docker-in-docker + MetalLB does not
-  # work reliably inside act's runner containers. The job is exercised on
+  # Skipped under local act runs — nested docker-in-docker (KinD cluster +
+  # cloud-provider-kind container on the `kind` network) does not work
+  # reliably inside act's runner containers. The job is exercised on
   # GitHub Actions runners on every push/tag/PR.
   e2e:
     if: vars.ACT != 'true'

--- a/Makefile
+++ b/Makefile
@@ -337,10 +337,7 @@ kind-create: deps-kind
 	@# cloud-provider-kind runs host-side (not in the cluster). It watches
 	@# Services of type LoadBalancer and allocates IPs on the `kind` Docker
 	@# network. Kind-team maintained (kubernetes-sigs/cloud-provider-kind),
-	@# so new kindest/node images are supported day-one. Supersedes the
-	@# previous MetalLB setup which required installing an in-cluster
-	@# controller + speaker DaemonSet + L2Advertisement YAML, plus had a
-	@# known nftables regression on kindest/node:v1.35.0.
+	@# so new kindest/node images are supported day-one. See ADR-0006.
 	@echo "Starting cloud-provider-kind $(CLOUD_PROVIDER_KIND_VERSION)..."
 	@docker rm -f cloud-provider-kind >/dev/null 2>&1 || true
 	@docker run --rm -d \


### PR DESCRIPTION
## Summary

Two inline comments still referenced MetalLB after PR #38 migrated to cloud-provider-kind:

- `Makefile` `kind-create`: trimmed the 5-line "Supersedes the previous MetalLB setup…" paragraph to a one-line `See ADR-0006` cross-reference — the context belongs in the ADR, not the recipe comment.
- `.github/workflows/ci.yml` e2e job skip-reason: changed "nested docker-in-docker + MetalLB does not work reliably inside act" to accurately describe the current stack (KinD cluster + cloud-provider-kind container on the `kind` network).

## Remaining MetalLB references (intentional, not cleaned up)

| Location | Why kept |
|---|---|
| `docs/adr/0003-*.md` body | Historical record — ADRs are immutable once accepted; we only updated its `Status:` to "Superseded by ADR-0006". |
| `docs/adr/0006-*.md` body | Records what we migrated *away from* — that's the ADR's purpose. |
| `docs/adr/README.md` index | Lists historical ADR titles. |
| `README.md:28` Tech Stack "Supersedes MetalLB — simpler lifecycle…" | Context for readers coming from old docs / bookmarks; prevents the "why am I not seeing MetalLB?" question. |
| `docs/reference-architecture.md:50, 834` | Same reason as README. |

## Test plan

- [ ] CI passes (zero-risk comment-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)