### PR TITLE
fix: pin BouncyCastle to 1.84 (CVE-2026-5598) — unblocks image-scan

### DIFF
--- a/department-service/pom.xml
+++ b/department-service/pom.xml
@@ -46,6 +46,28 @@
 				<artifactId>tomcat-embed-core</artifactId>
 				<version>11.0.22</version>
 			</dependency>
+			<!-- Override transitive BouncyCastle to fix CVE-2026-5598 (HIGH:
+			     BC-JAVA private key leakage via non-constant-time operation).
+			     Pulled in via spring-cloud-starter-kubernetes-client-all →
+			     io.kubernetes:client-java → bcpkix-jdk18on → bcutil-jdk18on
+			     → bcprov-jdk18on. Affected up to and including 1.80; fix is
+			     in 1.84. Remove when io.kubernetes:client-java ships a
+			     release that pulls bouncycastle 1.84+. -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcutil-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/employee-service/pom.xml
+++ b/employee-service/pom.xml
@@ -45,6 +45,28 @@
 				<artifactId>tomcat-embed-core</artifactId>
 				<version>11.0.22</version>
 			</dependency>
+			<!-- Override transitive BouncyCastle to fix CVE-2026-5598 (HIGH:
+			     BC-JAVA private key leakage via non-constant-time operation).
+			     Pulled in via spring-cloud-starter-kubernetes-client-all →
+			     io.kubernetes:client-java → bcpkix-jdk18on → bcutil-jdk18on
+			     → bcprov-jdk18on. Affected up to and including 1.80; fix is
+			     in 1.84. Remove when io.kubernetes:client-java ships a
+			     release that pulls bouncycastle 1.84+. -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcutil-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -86,6 +86,28 @@
 				<artifactId>tomcat-embed-core</artifactId>
 				<version>11.0.22</version>
 			</dependency>
+			<!-- Override transitive BouncyCastle to fix CVE-2026-5598 (HIGH:
+			     BC-JAVA private key leakage via non-constant-time operation).
+			     Pulled in via spring-cloud-starter-kubernetes-client-all →
+			     io.kubernetes:client-java → bcpkix-jdk18on → bcutil-jdk18on
+			     → bcprov-jdk18on. Affected up to and including 1.80; fix is
+			     in 1.84. Remove when io.kubernetes:client-java ships a
+			     release that pulls bouncycastle 1.84+. -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcutil-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/organization-service/pom.xml
+++ b/organization-service/pom.xml
@@ -44,6 +44,28 @@
 				<artifactId>tomcat-embed-core</artifactId>
 				<version>11.0.22</version>
 			</dependency>
+			<!-- Override transitive BouncyCastle to fix CVE-2026-5598 (HIGH:
+			     BC-JAVA private key leakage via non-constant-time operation).
+			     Pulled in via spring-cloud-starter-kubernetes-client-all →
+			     io.kubernetes:client-java → bcpkix-jdk18on → bcutil-jdk18on
+			     → bcprov-jdk18on. Affected up to and including 1.80; fix is
+			     in 1.84. Remove when io.kubernetes:client-java ships a
+			     release that pulls bouncycastle 1.84+. -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcutil-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>1.84</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/renovate.json
+++ b/renovate.json
@@ -111,6 +111,11 @@
       "groupName": "Micrometer"
     },
     {
+      "description": "Group BouncyCastle dependencies (bcpkix/bcutil/bcprov pinned together to address transitive CVEs from io.kubernetes:client-java; keep all three on the same version)",
+      "matchPackageNames": ["/^org\\.bouncycastle:/"],
+      "groupName": "BouncyCastle"
+    },
+    {
       "description": "Label Java packages",
       "matchCategories": ["java"],
       "addLabels": ["lang: java"]


### PR DESCRIPTION
## Summary

- Pin `org.bouncycastle:{bcpkix,bcutil,bcprov}-jdk18on` to **1.84** in each module's `<dependencyManagement>` to fix **CVE-2026-5598** (HIGH — *BC-JAVA: private key leakage via non-constant-time operation*). Affected up to and including 1.80.
- Add a Renovate group `BouncyCastle` so future bumps land in a single PR (the three artifacts must move together).

## Why now

The `image-scan` job has been failing on every PR (e.g. #53 cosign-installer bump) with:

```
org.bouncycastle:bcprov-jdk18on (bcprov-jdk18on-1.80.jar)
  CVE-2026-5598  HIGH  fixed  1.80 → 1.84
```

Trivy fails the build on `severity: CRITICAL,HIGH; ignore-unfixed: true`. The CVE was independent of any PR diff — it was already on master. This PR clears it.

## Dependency chain

```
spring-cloud-starter-kubernetes-client-all
  └─ io.kubernetes:client-java
     └─ bcpkix-jdk18on → bcutil-jdk18on → bcprov-jdk18on
```

`io.kubernetes:client-java` (latest GA) still pulls 1.80; the override is the only path until upstream picks up 1.84.

## Verification

- `mvn dependency:tree -Dincludes='org.bouncycastle:*'` resolves 1.84 across all 4 services (was 1.80).
- `unzip -l <svc>/target/<svc>-1.1.jar | grep bc` confirms `bcprov-jdk18on-1.84.jar`, `bcpkix-jdk18on-1.84.jar`, `bcutil-jdk18on-1.84.jar` are bundled in every fat jar.
- `make build` and `make test` pass clean (no new warnings).
- Renovate config validated as JSON.

## Test plan

- [ ] CI `build`, `test`, `integration-test`, `e2e`, `static-check` pass
- [ ] CI `image-scan` (4-service matrix) passes — Trivy no longer reports CVE-2026-5598
- [ ] After merge: rebase #53 onto master and confirm its `image-scan` clears

## Cleanup trigger

Remove the override when `io.kubernetes:client-java` ships a release that pulls BouncyCastle ≥ 1.84 transitively (Renovate will surface the version-alignment opportunity). Comment in each pom encodes the trigger.