### PR TITLE
fix: project-review followups — controller 404 contract, integration tests, e2e status checks, Docker structure test

### DIFF
--- a/.container-structure-test.yaml
+++ b/.container-structure-test.yaml
@@ -1,0 +1,37 @@
+# container-structure-test config — validates the OCI-manifest-level Dockerfile
+# contract for every published service image (gateway, employee, department,
+# organization). The four Dockerfiles share the same shape (multi-stage extract
+# + eclipse-temurin jre-noble runtime, non-root UID 10001, EXPOSE 8080,
+# ENTRYPOINT java -jar app.jar) so one config validates all four.
+#
+# Why a separate gate from Trivy + smoke test:
+#   - Trivy catches CVEs in the image layers (vuln/secret/misconfig).
+#   - The smoke test proves the JVM starts and Spring Boot boots.
+#   - This config catches Dockerfile-contract drift — a USER reset to root
+#     (silently nullifies pod-security restrictions), a wrong EXPOSE (breaks
+#     Kubernetes Service routing), a changed entrypoint (never reaches main).
+#   None of the other two gates would catch these.
+#
+# Runner: gcr.io/gcp-runtimes/container-structure-test (pinned in
+# .github/workflows/ci.yml and Makefile).
+schemaVersion: 2.0.0
+
+metadataTest:
+  user: "10001"
+  exposedPorts:
+    - "8080"
+  workdir: "/application"
+  entrypoint:
+    - "java"
+    - "-jar"
+    - "app.jar"
+
+commandTests:
+  # Orthogonal to metadataTest.user — proves the image ACTUALLY runs as UID
+  # 10001 at startup. A later layer could in principle override USER; only
+  # `id -u` inside the running container settles the runtime identity.
+  - name: "container runs as non-root UID 10001"
+    command: "id"
+    args: ["-u"]
+    expectedOutput:
+      - "^10001$"

--- a/.container-structure-test.yaml
+++ b/.container-structure-test.yaml
@@ -30,8 +30,12 @@ commandTests:
   # Orthogonal to metadataTest.user — proves the image ACTUALLY runs as UID
   # 10001 at startup. A later layer could in principle override USER; only
   # `id -u` inside the running container settles the runtime identity.
+  # The `(?m)` inline flag enables multiline mode so `$` matches before the
+  # trailing newline `id -u` always emits — without it, `^10001$` fails on
+  # the literal output `10001\n` (container-structure-test runs Go regex
+  # against the full stdout, not line-by-line).
   - name: "container runs as non-root UID 10001"
     command: "id"
     args: ["-u"]
     expectedOutput:
-      - "^10001$"
+      - "(?m)^10001$"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,6 @@ jobs:
         with:
           context: ./${{ matrix.service }}-service
           file: ./${{ matrix.service }}-service/Dockerfile
-          build-args: VARIANT=debug
           platforms: linux/amd64
           load: true
           tags: ${{ matrix.service }}:scan
@@ -380,6 +379,20 @@ jobs:
           docker logs "${SVC}-smoke"
           docker rm -f "${SVC}-smoke" >/dev/null || true
           exit 1
+
+      # Validates the OCI-manifest-level Dockerfile contract (USER non-root,
+      # EXPOSE port, WORKDIR, ENTRYPOINT) with container-structure-test.
+      # Orthogonal to Trivy (CVE/secret/misconfig) and the smoke test (runtime
+      # boot) — catches a USER reset to root, a wrong port, a changed
+      # entrypoint. Runs on every push so Dockerfile-contract drift fails the
+      # commit that introduced it, not just the release.
+      - name: Container structure test
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$PWD/.container-structure-test.yaml:/test.yaml:ro" \
+            gcr.io/gcp-runtimes/container-structure-test:v1.19.3 \
+            test --image "${{ matrix.service }}:scan" --config /test.yaml
 
       - name: Cleanup smoke container
         if: always()
@@ -477,7 +490,6 @@ jobs:
         with:
           context: ./${{ matrix.service }}-service
           file: ./${{ matrix.service }}-service/Dockerfile
-          build-args: VARIANT=debug
           platforms: linux/amd64
           load: true
           tags: ${{ matrix.service }}:scan
@@ -547,7 +559,6 @@ jobs:
         with:
           context: ./${{ matrix.service }}-service
           file: ./${{ matrix.service }}-service/Dockerfile
-          build-args: VARIANT=debug
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$PWD/.container-structure-test.yaml:/test.yaml:ro" \
-            gcr.io/gcp-runtimes/container-structure-test:v1.19.3 \
+            gcr.io/gcp-runtimes/container-structure-test:v1.16.0 \
             test --image "${{ matrix.service }}:scan" --config /test.yaml
 
       - name: Cleanup smoke container

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,12 @@
-# MongoDB requires writable filesystem for /data/db — readOnlyRootFilesystem breaks it
+# MongoDB requires writable filesystem for /data/db — readOnlyRootFilesystem breaks it.
+# Removal trigger: MongoDB image ships an emptyDir-only data layout (none planned upstream);
+# OR the project moves to an external managed-MongoDB (Atlas/cloud) and removes the in-cluster
+# pod. Re-evaluate on every Renovate-driven mongo image bump.
 KSV-0014
 
-# Spring Cloud Kubernetes requires get/list/watch on secrets for secret PropertySource loading
+# Spring Cloud Kubernetes requires get/list/watch on secrets for secret PropertySource loading.
+# Removal trigger: Spring Cloud Kubernetes 4.x adds a config-only mode that drops the secret
+# permission requirement (track spring-cloud/spring-cloud-kubernetes#1768 family); OR the project
+# switches secret material to a CSI-driver-mounted source (e.g., Secrets Store CSI) and removes
+# the API-level Secret reads from RBAC. Re-evaluate on every Spring Cloud bump.
 KSV-0041

--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ container-structure-test: deps-docker image-build
 		docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v "$(CURDIR)/.container-structure-test.yaml:/test.yaml:ro" \
-			gcr.io/gcp-runtimes/container-structure-test:v1.19.3 \
+			gcr.io/gcp-runtimes/container-structure-test:v1.16.0 \
 			test --image $$svc:$(IMAGE_TAG) --config /test.yaml; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,20 @@ static-check: deps format-check diagrams-check mermaid-lint lint-ci lint lint-do
 image-build: deps-docker build
 	@for svc in $(SERVICES); do \
 		echo "Building $$svc:$(IMAGE_TAG)..."; \
-		BUILDX_BUILDER=default docker buildx build --load --build-arg VARIANT=debug -t $$svc:$(IMAGE_TAG) -f $$svc-service/Dockerfile $$svc-service/; \
+		BUILDX_BUILDER=default docker buildx build --load -t $$svc:$(IMAGE_TAG) -f $$svc-service/Dockerfile $$svc-service/; \
+	done
+
+#container-structure-test: @ Validate Dockerfile contracts (USER, EXPOSE, ENTRYPOINT) on built images
+# Mirrors the CI `image-scan` step. The shared .container-structure-test.yaml config
+# applies to all 4 services because their Dockerfiles follow the same shape.
+container-structure-test: deps-docker image-build
+	@for svc in $(SERVICES); do \
+		echo "Container structure test: $$svc"; \
+		docker run --rm \
+			-v /var/run/docker.sock:/var/run/docker.sock \
+			-v "$(CURDIR)/.container-structure-test.yaml:/test.yaml:ro" \
+			gcr.io/gcp-runtimes/container-structure-test:v1.19.3 \
+			test --image $$svc:$(IMAGE_TAG) --config /test.yaml; \
 	done
 
 #image-load: @ Load Docker images into KinD cluster
@@ -628,7 +641,7 @@ renovate-validate: renovate-bootstrap
 	diagrams diagrams-check diagrams-clean mermaid-lint \
 	maven-settings-ossindex cve-check \
 	coverage-generate coverage-check coverage-open static-check \
-	image-build image-load \
+	image-build image-load container-structure-test \
 	kind-create kind-setup kind-deploy kind-undeploy kind-redeploy kind-destroy kind-up kind-down \
 	e2e e2e-test populate \
 	gateway-url gateway-open jaeger-open \

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Three-layer test pyramid: unit → integration → end-to-end. Each layer runs i
 | `make diagrams` | Render PlantUML architecture diagrams under `docs/diagrams/` to PNG |
 | `make diagrams-check` | Verify committed PNGs match current `.puml` source (drift check for CI) |
 | `make diagrams-clean` | Remove rendered diagram PNGs |
+| `make container-structure-test` | Validate Dockerfile contracts (USER, EXPOSE, ENTRYPOINT) on built images |
 | `make cve-check` | Run OWASP dependency vulnerability scan |
 | `make coverage-generate` | Generate code coverage report |
 | `make coverage-check` | Verify code coverage meets minimum threshold |
@@ -280,7 +281,7 @@ GitHub Actions runs on every push to `master`, tags `v*`, and pull requests.
 | **test** | after static-check | Surefire unit + in-process controller tests (`**/*Test.java`) with JaCoCo coverage |
 | **integration-test** | after static-check | Failsafe Testcontainers integration tests (`**/*IT.java`) — real MongoDB per class plus WireMock for cross-service stubs |
 | **cve-check** | push to master AND tag pushes (skipped under `act`) | OWASP dependency vulnerability scan — gates the `docker` job on tag pushes |
-| **image-scan** | every push (matrix: 4 services) | Per-service Dockerfile validation gates 1–3: build single-arch image → Trivy image scan (CRITICAL/HIGH blocking) → Spring Boot boot-marker smoke test. Catches base-image CVE regressions and Dockerfile breakages on the commit that introduced them, not on release day. |
+| **image-scan** | every push (matrix: 4 services) | Per-service Dockerfile validation gates: build single-arch image → Trivy image scan (CRITICAL/HIGH blocking) → Spring Boot boot-marker smoke test → container-structure-test (OCI-manifest contract: USER non-root, EXPOSE, WORKDIR, ENTRYPOINT). Catches base-image CVE regressions, runtime breakages, and Dockerfile-contract drift on the commit that introduced them, not on release day. |
 | **e2e** | push/PR when KinD-relevant files change (skipped under `act`) | End-to-end test against a full Kind + cloud-provider-kind stack: `make e2e` cycles create → setup (MongoDB) → deploy (4 services + gateway LB) → `./e2e/e2e-test.sh` → destroy. |
 | **docker** | tag push only (matrix: 4 services) | Full pre-push hardening: build local image → Trivy image scan → Spring Boot smoke test → multi-arch (amd64+arm64) build with SLSA provenance + SBOM attestation → push to GHCR → cosign keyless OIDC signing. Depends on `build`, `test`, `cve-check`. |
 | **ci-pass** | always | Branch-protection aggregator: single required status check that verifies no upstream job failed or was cancelled. Skipped jobs do not trip the gate. |

--- a/department-service/src/main/java/vmware/services/department/controller/DepartmentController.java
+++ b/department-service/src/main/java/vmware/services/department/controller/DepartmentController.java
@@ -4,11 +4,13 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import vmware.services.department.client.EmployeeClient;
 import vmware.services.department.model.Department;
 import vmware.services.department.repository.DepartmentRepository;
@@ -31,7 +33,9 @@ public class DepartmentController {
   @GetMapping("/{id}")
   public Department findById(@PathVariable("id") String id) {
     LOGGER.info("Department find: id={}", id);
-    return repository.findById(id).get();
+    return repository
+        .findById(id)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Department " + id));
   }
 
   @GetMapping("/")

--- a/department-service/src/test/java/vmware/services/department/DepartmentNotFoundIT.java
+++ b/department-service/src/test/java/vmware/services/department/DepartmentNotFoundIT.java
@@ -1,0 +1,35 @@
+package vmware.services.department;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.client.RestTestClient;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+/**
+ * Locks the {@code GET /{id}} not-found contract for the department service. Earlier the controller
+ * called {@code repository.findById(id).get()}, which threw {@code NoSuchElementException} and
+ * surfaced as a 500 — inconsistent with the employee-service contract. The controller now maps a
+ * missing id to {@link org.springframework.web.server.ResponseStatusException} with {@code 404};
+ * this test pins that behavior so the inconsistency cannot silently come back.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureRestTestClient
+@Testcontainers
+@ActiveProfiles("test")
+class DepartmentNotFoundIT {
+
+  @Container @ServiceConnection static MongoDBContainer mongo = new MongoDBContainer("mongo:8.3.2");
+
+  @Autowired RestTestClient client;
+
+  @Test
+  void shouldReturn404WhenDepartmentIdIsUnknown() {
+    client.get().uri("/unknown-department-id").exchange().expectStatus().isNotFound();
+  }
+}

--- a/department-service/src/test/java/vmware/services/department/DepartmentWithEmployeesIT.java
+++ b/department-service/src/test/java/vmware/services/department/DepartmentWithEmployeesIT.java
@@ -119,6 +119,33 @@ class DepartmentWithEmployeesIT {
   }
 
   /**
+   * Locks the current peer-failure contract: when the employee-service peer returns 5xx, the
+   * controller has no graceful-degradation path — the exception from {@link
+   * vmware.services.department.client.EmployeeClient} propagates and the gateway-side caller sees
+   * 5xx too. If a future change adds graceful degradation (e.g., return the department with an
+   * empty {@code employees[]} array on peer failure), this assertion is updated intentionally.
+   */
+  @Test
+  void shouldPropagatePeerFailureWhenEmployeeServiceReturns5xx() {
+    Department engineering = repository.save(new Department(42L, "Engineering"));
+    String deptId = engineering.getId();
+
+    wireMock.stubFor(
+        get(urlPathMatching("/department/" + deptId))
+            .willReturn(aResponse().withStatus(500).withBody("Employee Service Down")));
+
+    client
+        .get()
+        .uri("/organization/42/with-employees")
+        .exchange()
+        .expectStatus()
+        .is5xxServerError();
+
+    // The peer WAS called — the controller's failure isn't a short-circuit, it's a propagated 5xx.
+    wireMock.verify(getRequestedFor(urlPathMatching("/department/" + deptId)));
+  }
+
+  /**
    * Test-scoped override for {@link EmployeeClient}. The main configuration builds the client
    * against {@code http://employee} (resolved via Spring Cloud LoadBalancer). For integration
    * testing we point it at the WireMock baseUrl injected via {@code @DynamicPropertySource}.

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -49,6 +49,37 @@ check_response() {
   fi
 }
 
+# Assert HTTP status AND body substring on a POST request, in a single curl.
+# A substring-only `check_response` after a separate curl would falsely PASS on
+# a 5xx whose body echoes the input ("Smith" appears in both 200 OK and a 500
+# stack trace mentioning the payload).
+check_post() {
+  local test_name="$1"
+  local url="$2"
+  local body="$3"
+  local expected_status="$4"
+  local expected_body="$5"
+  local tmp
+  tmp=$(mktemp)
+  local actual_status
+  actual_status=$(curl -s -o "${tmp}" -w '%{http_code}' \
+    -X POST -H 'Content-Type: application/json' --max-time 30 \
+    -d "${body}" "${url}" 2>/dev/null || true)
+  local actual_body
+  actual_body=$(cat "${tmp}")
+  rm -f "${tmp}"
+  if [[ "${actual_status}" == "${expected_status}" ]] \
+    && echo "${actual_body}" | grep -qF "${expected_body}"; then
+    echo "  PASS: ${test_name} (HTTP ${actual_status})"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: ${test_name}"
+    echo "        expected: HTTP ${expected_status}, body contains '${expected_body}'"
+    echo "        actual:   HTTP ${actual_status}, body: ${actual_body}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 # Assert HTTP status code for a request.
 check_status() {
   local test_name="$1"
@@ -147,17 +178,17 @@ check_response "GET /actuator/health returns UP" "${RESP}" "UP"
 
 # Test 2: Create employee Smith ----------------------------------------------
 echo "[Test 2] Create employee Smith"
-RESP=$(curl -s --max-time 30 -X POST "${BASE_URL}/employee/" \
-  -H "Content-Type: application/json" \
-  -d '{"age":25,"departmentId":1,"id":"1","name":"Smith","organizationId":1,"position":"engineer"}' 2>/dev/null || true)
-check_response "POST /employee/ — Smith created" "${RESP}" "Smith"
+check_post "POST /employee/ — Smith created" \
+  "${BASE_URL}/employee/" \
+  '{"age":25,"departmentId":1,"id":"1","name":"Smith","organizationId":1,"position":"engineer"}' \
+  200 "Smith"
 
 # Test 3: Create employee Johns ----------------------------------------------
 echo "[Test 3] Create employee Johns"
-RESP=$(curl -s --max-time 30 -X POST "${BASE_URL}/employee/" \
-  -H "Content-Type: application/json" \
-  -d '{"age":45,"departmentId":1,"id":"2","name":"Johns","organizationId":1,"position":"manager"}' 2>/dev/null || true)
-check_response "POST /employee/ — Johns created" "${RESP}" "Johns"
+check_post "POST /employee/ — Johns created" \
+  "${BASE_URL}/employee/" \
+  '{"age":45,"departmentId":1,"id":"2","name":"Johns","organizationId":1,"position":"manager"}' \
+  200 "Johns"
 
 # Test 4: List employees ------------------------------------------------------
 echo "[Test 4] List employees"
@@ -167,10 +198,10 @@ check_response "GET /employee/ — contains Johns" "${RESP}" "Johns"
 
 # Test 5: Create department ---------------------------------------------------
 echo "[Test 5] Create department"
-RESP=$(curl -s --max-time 30 -X POST "${BASE_URL}/department/" \
-  -H "Content-Type: application/json" \
-  -d '{"id":"1","name":"RD Dept.","organizationId":1}' 2>/dev/null || true)
-check_response "POST /department/ — RD Dept. created" "${RESP}" "RD Dept."
+check_post "POST /department/ — RD Dept. created" \
+  "${BASE_URL}/department/" \
+  '{"id":"1","name":"RD Dept.","organizationId":1}' \
+  200 "RD Dept."
 
 # Test 6: List departments ----------------------------------------------------
 echo "[Test 6] List departments"
@@ -179,10 +210,10 @@ check_response "GET /department/ — contains RD Dept." "${RESP}" "RD Dept."
 
 # Test 7: Create organization -------------------------------------------------
 echo "[Test 7] Create organization"
-RESP=$(curl -s --max-time 30 -X POST "${BASE_URL}/organization/" \
-  -H "Content-Type: application/json" \
-  -d '{"id":"1","name":"MegaCorp","address":"Main Street"}' 2>/dev/null || true)
-check_response "POST /organization/ — MegaCorp created" "${RESP}" "MegaCorp"
+check_post "POST /organization/ — MegaCorp created" \
+  "${BASE_URL}/organization/" \
+  '{"id":"1","name":"MegaCorp","address":"Main Street"}' \
+  200 "MegaCorp"
 
 # Test 8: Get organization with employees (cross-service) ---------------------
 echo "[Test 8] Get organization with employees (cross-service)"
@@ -211,12 +242,35 @@ check_jq "deep fan-out response has at least one department" "${RESP}" \
 check_jq "deep fan-out response first department has employees[] array" "${RESP}" \
   '.departments[0].employees | type' "array"
 
-# Test 11: Negative — GET unknown employee id ---------------------------------
-# EmployeeController.findById throws ResponseStatusException(NOT_FOUND) when the
-# id is missing — surfaces through the gateway as a 404.
-echo "[Test 11] Negative: GET /employee/nonexistent — expect 404"
+# Test 11: Negative — GET unknown id across services ------------------------
+# Every service's findById maps a missing id to ResponseStatusException(NOT_FOUND)
+# — surfaces through the gateway as a 404. Earlier the department / organization
+# controllers called `findById(id).get()` (NoSuchElementException → 500) and the
+# three `/{id}/with-*` endpoints `return null` (200 with a null body); each now
+# throws 404 and the with-* endpoints short-circuit before any peer fan-out.
+echo "[Test 11a] Negative: GET /employee/nonexistent — expect 404"
 check_status "GET /employee/nonexistent-id returns 404" \
   GET "${BASE_URL}/employee/nonexistent-id" 404
+
+echo "[Test 11b] Negative: GET /department/nonexistent — expect 404"
+check_status "GET /department/nonexistent-id returns 404" \
+  GET "${BASE_URL}/department/nonexistent-id" 404
+
+echo "[Test 11c] Negative: GET /organization/nonexistent — expect 404"
+check_status "GET /organization/nonexistent-id returns 404" \
+  GET "${BASE_URL}/organization/nonexistent-id" 404
+
+echo "[Test 11d] Negative: GET /organization/nonexistent/with-departments — expect 404"
+check_status "GET /organization/nonexistent-id/with-departments returns 404" \
+  GET "${BASE_URL}/organization/nonexistent-id/with-departments" 404
+
+echo "[Test 11e] Negative: GET /organization/nonexistent/with-employees — expect 404"
+check_status "GET /organization/nonexistent-id/with-employees returns 404" \
+  GET "${BASE_URL}/organization/nonexistent-id/with-employees" 404
+
+echo "[Test 11f] Negative: GET /organization/nonexistent/with-departments-and-employees — expect 404"
+check_status "GET /organization/nonexistent-id/with-departments-and-employees returns 404" \
+  GET "${BASE_URL}/organization/nonexistent-id/with-departments-and-employees" 404
 
 # Test 12: Negative — POST employee with malformed JSON body ------------------
 # Jackson rejects invalid JSON with 400 Bad Request before the controller runs.

--- a/employee-service/src/test/java/vmware/services/employee/EmployeeFinderIT.java
+++ b/employee-service/src/test/java/vmware/services/employee/EmployeeFinderIT.java
@@ -1,0 +1,102 @@
+package vmware.services.employee;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.client.RestTestClient;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import vmware.services.employee.model.Employee;
+import vmware.services.employee.repository.EmployeeRepository;
+
+/**
+ * Controller-layer integration test for the foreign-key finder endpoints — {@code GET
+ * /department/{id}} and {@code GET /organization/{id}}. {@link EmployeeRepositoryIT} exercises the
+ * same finders at the repository slice; this test pins the HTTP contract (path, media type,
+ * return-shape) end-to-end through the controller, so a change to the controller route or
+ * response-binding cannot regress silently.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureRestTestClient
+@Testcontainers
+@ActiveProfiles("test")
+class EmployeeFinderIT {
+
+  @Container @ServiceConnection static MongoDBContainer mongo = new MongoDBContainer("mongo:8.3.2");
+
+  @Autowired RestTestClient client;
+
+  @Autowired EmployeeRepository repository;
+
+  @BeforeEach
+  void seed() {
+    repository.deleteAll();
+    repository.save(new Employee(1L, 1L, "Alice", 30, "engineer"));
+    repository.save(new Employee(1L, 1L, "Bob", 35, "architect"));
+    repository.save(new Employee(1L, 2L, "Carol", 28, "manager"));
+    repository.save(new Employee(2L, 3L, "Dave", 40, "director"));
+  }
+
+  @Test
+  void shouldReturnEmployeesByDepartmentId() {
+    client
+        .get()
+        .uri("/department/1")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(Employee[].class)
+        .value(
+            body ->
+                assertThat(body)
+                    .extracting(Employee::getName)
+                    .containsExactlyInAnyOrder("Alice", "Bob"));
+  }
+
+  @Test
+  void shouldReturnEmptyArrayForUnknownDepartmentId() {
+    client
+        .get()
+        .uri("/department/999")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(Employee[].class)
+        .value(body -> assertThat(body).isEmpty());
+  }
+
+  @Test
+  void shouldReturnEmployeesByOrganizationId() {
+    client
+        .get()
+        .uri("/organization/1")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(Employee[].class)
+        .value(
+            body ->
+                assertThat(body)
+                    .extracting(Employee::getName)
+                    .containsExactlyInAnyOrder("Alice", "Bob", "Carol"));
+  }
+
+  @Test
+  void shouldIsolateTenantsByOrganizationId() {
+    client
+        .get()
+        .uri("/organization/2")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(Employee[].class)
+        .value(body -> assertThat(body).extracting(Employee::getName).containsExactly("Dave"));
+  }
+}

--- a/employee-service/src/test/java/vmware/services/employee/EmployeeNotFoundIT.java
+++ b/employee-service/src/test/java/vmware/services/employee/EmployeeNotFoundIT.java
@@ -1,0 +1,34 @@
+package vmware.services.employee;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.client.RestTestClient;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+
+/**
+ * Locks the {@code GET /{id}} not-found contract for the employee service. The controller maps a
+ * missing id to {@link org.springframework.web.server.ResponseStatusException} with {@code 404}
+ * (rather than letting the repository's empty {@code Optional} surface as a 500). This test is the
+ * integration-layer floor for that contract; e2e covers the same shape through the gateway.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureRestTestClient
+@Testcontainers
+@ActiveProfiles("test")
+class EmployeeNotFoundIT {
+
+  @Container @ServiceConnection static MongoDBContainer mongo = new MongoDBContainer("mongo:8.3.2");
+
+  @Autowired RestTestClient client;
+
+  @Test
+  void shouldReturn404WhenEmployeeIdIsUnknown() {
+    client.get().uri("/unknown-employee-id").exchange().expectStatus().isNotFound();
+  }
+}

--- a/organization-service/src/main/java/vmware/services/organization/controller/OrganizationController.java
+++ b/organization-service/src/main/java/vmware/services/organization/controller/OrganizationController.java
@@ -1,14 +1,15 @@
 package vmware.services.organization.controller;
 
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import vmware.services.organization.client.DepartmentClient;
 import vmware.services.organization.client.EmployeeClient;
 import vmware.services.organization.model.Organization;
@@ -40,45 +41,43 @@ public class OrganizationController {
   @GetMapping("/{id}")
   public Organization findById(@PathVariable("id") String id) {
     LOGGER.info("Organization find: id={}", id);
-    return repository.findById(id).get();
+    return repository
+        .findById(id)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Organization " + id));
   }
 
   @GetMapping("/{id}/with-departments")
   public Organization findByIdWithDepartments(@PathVariable("id") String id) {
     LOGGER.info("Organization find: id={}", id);
-    Optional<Organization> organization = repository.findById(id);
-    if (organization.isPresent()) {
-      Organization o = organization.get();
-      o.setDepartments(departmentClient.findByOrganization(o.getId()));
-      return o;
-    } else {
-      return null;
-    }
+    Organization o = loadOrThrow(id);
+    o.setDepartments(departmentClient.findByOrganization(o.getId()));
+    return o;
   }
 
   @GetMapping("/{id}/with-departments-and-employees")
   public Organization findByIdWithDepartmentsAndEmployees(@PathVariable("id") String id) {
     LOGGER.info("Organization find: id={}", id);
-    Optional<Organization> organization = repository.findById(id);
-    if (organization.isPresent()) {
-      Organization o = organization.get();
-      o.setDepartments(departmentClient.findByOrganizationWithEmployees(o.getId()));
-      return o;
-    } else {
-      return null;
-    }
+    Organization o = loadOrThrow(id);
+    o.setDepartments(departmentClient.findByOrganizationWithEmployees(o.getId()));
+    return o;
   }
 
   @GetMapping("/{id}/with-employees")
   public Organization findByIdWithEmployees(@PathVariable("id") String id) {
     LOGGER.info("Organization find: id={}", id);
-    Optional<Organization> organization = repository.findById(id);
-    if (organization.isPresent()) {
-      Organization o = organization.get();
-      o.setEmployees(employeeClient.findByOrganization(o.getId()));
-      return o;
-    } else {
-      return null;
-    }
+    Organization o = loadOrThrow(id);
+    o.setEmployees(employeeClient.findByOrganization(o.getId()));
+    return o;
+  }
+
+  /**
+   * Load the organization or throw 404. Single source for the missing-id contract across {@code
+   * /{id}/with-*} endpoints — short-circuits before any peer fan-out so a missing org never fires
+   * downstream calls.
+   */
+  private Organization loadOrThrow(String id) {
+    return repository
+        .findById(id)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Organization " + id));
   }
 }

--- a/organization-service/src/test/java/vmware/services/organization/OrganizationNotFoundIT.java
+++ b/organization-service/src/test/java/vmware/services/organization/OrganizationNotFoundIT.java
@@ -1,0 +1,150 @@
+package vmware.services.organization;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.client.RestTestClient;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import vmware.services.organization.client.DepartmentClient;
+import vmware.services.organization.client.EmployeeClient;
+import vmware.services.organization.repository.OrganizationRepository;
+
+/**
+ * Locks the not-found contract across every {@code GET /{id}} endpoint on the organization service.
+ * Earlier {@code findById} called {@code .get()} (NoSuchElementException → 500) and the three
+ * {@code /{id}/with-*} endpoints {@code return null} when the org was missing (200 with a {@code
+ * null} body — semantically wrong). Each now throws {@link
+ * org.springframework.web.server.ResponseStatusException} with {@code 404}.
+ *
+ * <p>The peer WireMock stubs are present specifically so the test can assert <em>zero</em> requests
+ * were issued — the controller MUST short-circuit on the missing org before any fan-out.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = "spring.main.allow-bean-definition-overriding=true")
+@AutoConfigureRestTestClient
+@Testcontainers
+@ActiveProfiles("test")
+@Import(OrganizationNotFoundIT.WireMockClientsConfig.class)
+class OrganizationNotFoundIT {
+
+  @Container @ServiceConnection static MongoDBContainer mongo = new MongoDBContainer("mongo:8.3.2");
+
+  static WireMockServer departmentStub;
+
+  static WireMockServer employeeStub;
+
+  @Autowired RestTestClient client;
+
+  @Autowired OrganizationRepository repository;
+
+  @BeforeAll
+  static void startWireMock() {
+    departmentStub = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+    employeeStub = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+    departmentStub.start();
+    employeeStub.start();
+  }
+
+  @AfterAll
+  static void stopWireMock() {
+    if (departmentStub != null) {
+      departmentStub.stop();
+    }
+    if (employeeStub != null) {
+      employeeStub.stop();
+    }
+  }
+
+  @DynamicPropertySource
+  static void registerWireMockUrls(DynamicPropertyRegistry registry) {
+    registry.add("wiremock.department.base-url", () -> departmentStub.baseUrl());
+    registry.add("wiremock.employee.base-url", () -> employeeStub.baseUrl());
+  }
+
+  @BeforeEach
+  void resetState() {
+    repository.deleteAll();
+    departmentStub.resetAll();
+    employeeStub.resetAll();
+  }
+
+  @Test
+  void shouldReturn404OnFindByIdWhenOrgIsUnknown() {
+    client.get().uri("/unknown-org-id").exchange().expectStatus().isNotFound();
+  }
+
+  @Test
+  void shouldReturn404OnWithDepartmentsWhenOrgIsUnknownAndNotCallPeer() {
+    client.get().uri("/unknown-org-id/with-departments").exchange().expectStatus().isNotFound();
+
+    // The controller must short-circuit before the department peer call.
+    departmentStub.verify(0, anyRequestedFor(anyUrl()));
+  }
+
+  @Test
+  void shouldReturn404OnWithEmployeesWhenOrgIsUnknownAndNotCallPeer() {
+    client.get().uri("/unknown-org-id/with-employees").exchange().expectStatus().isNotFound();
+
+    employeeStub.verify(0, anyRequestedFor(anyUrl()));
+  }
+
+  @Test
+  void shouldReturn404OnWithDepartmentsAndEmployeesWhenOrgIsUnknownAndNotCallPeer() {
+    client
+        .get()
+        .uri("/unknown-org-id/with-departments-and-employees")
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+
+    // Deepest fan-out must short-circuit on the missing org — neither peer is touched.
+    departmentStub.verify(0, anyRequestedFor(anyUrl()));
+    employeeStub.verify(0, anyRequestedFor(anyUrl()));
+  }
+
+  @TestConfiguration
+  static class WireMockClientsConfig {
+
+    @Bean
+    @Primary
+    DepartmentClient departmentClient(@Value("${wiremock.department.base-url}") String baseUrl) {
+      RestClient restClient = RestClient.builder().baseUrl(baseUrl).build();
+      return HttpServiceProxyFactory.builderFor(RestClientAdapter.create(restClient))
+          .build()
+          .createClient(DepartmentClient.class);
+    }
+
+    @Bean
+    @Primary
+    EmployeeClient employeeClient(@Value("${wiremock.employee.base-url}") String baseUrl) {
+      RestClient restClient = RestClient.builder().baseUrl(baseUrl).build();
+      return HttpServiceProxyFactory.builderFor(RestClientAdapter.create(restClient))
+          .build()
+          .createClient(EmployeeClient.class);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Addresses every HIGH, MEDIUM, and LOW finding from the `/project-review` Docker-pipeline and test-coverage sub-agents — real fixes only, no workarounds, fact-checked against the actual source.

### Real product bug — `GET /{id}` was 500 on dept/org

- `DepartmentController.findById` and `OrganizationController.findById` called `repository.findById(id).get()` → `NoSuchElementException` → **500** on a missing id, while `EmployeeController` already returned 404. Both now throw `ResponseStatusException(NOT_FOUND, ...)`.
- `OrganizationController`'s three `/{id}/with-*` endpoints `return null` on a missing org (200 with a `null` JSON body — semantically wrong). All three now throw 404 and short-circuit **before** any peer fan-out (the new IT asserts zero peer requests).

### Integration tests — 11 new cases across 5 files (all pass locally)

| File | Tests | What it locks |
|------|-------|---------------|
| `EmployeeNotFoundIT` | 1 | 404 contract at integration level (was only covered at e2e) |
| `DepartmentNotFoundIT` | 1 | Proves the dept controller fix |
| `OrganizationNotFoundIT` | 4 | Proves the org controller fix across `/{id}` + all three `/{id}/with-*`; **asserts zero peer calls** on a missing org |
| `EmployeeFinderIT` | 4 | Controller-layer test for `/department/{id}` and `/organization/{id}` FK finders |
| `DepartmentWithEmployeesIT` (extended) | +1 | Peer-5xx contract — locks current propagate-5xx behaviour so any future graceful-degradation change is intentional |

```
[INFO] BUILD SUCCESS — Tests: 25 across 11 IT classes, 0 failures
```

### e2e — `e2e/e2e-test.sh`

- New `check_post` helper asserts **HTTP status AND body substring** in a single curl. The four POST tests (Smith, Johns, RD Dept., MegaCorp) now assert HTTP 200 in addition to the body shape — a 5xx that echoed the input would have falsely PASSed under the substring-only check.
- Six negative GET tests (`11a` through `11f`) prove the 404 contract through the gateway: `/employee/<unknown>`, `/department/<unknown>`, `/organization/<unknown>`, and the three `/organization/<unknown>/with-*` endpoints.

### Docker image pipeline

- **Remove inert `build-args: VARIANT=debug`** from `.github/workflows/ci.yml` (×3 sites) and the Makefile `image-build` recipe — no Dockerfile declares `ARG VARIANT`, the build-arg was silently doing nothing.
- **`.trivyignore`** — both `KSV-0014` (MongoDB read-only-fs) and `KSV-0041` (Spring Cloud K8s secret RBAC) now carry an explicit **removal trigger** as the skill requires; before, they had a rationale but no removal-policy line.
- **`.container-structure-test.yaml`** + `make container-structure-test` target + a new CI step in `image-scan` (4-service matrix, every push) — OCI-manifest contract gate asserting `USER 10001`, `EXPOSE 8080`, `WORKDIR /application`, `ENTRYPOINT ["java","-jar","app.jar"]`, plus runtime `id -u == 10001`. Orthogonal to Trivy (CVE/secret/misconfig) and the smoke test (runtime boot) — catches `USER` reset to root, wrong port, changed entrypoint; none of which the other two gates catch.

### README

- Pre-push image hardening: `image-scan` job description updated to mention the structure-test gate.
- Code Quality table: `make container-structure-test` added.

### Not changed (deliberate, documented)

- **Pattern B** (`provenance: mode=max` + `sbom: true`) stays — a conscious architectural choice per the CLAUDE.md MEMORY note (it adds `unknown/unknown` rows to the GHCR UI but provides SLSA L2 supply-chain attestations). Not a fix-by-downgrade.

## Test plan

- [x] `make help` — Makefile parses with new `container-structure-test` target
- [x] `make format` — google-java-format applied to new IT files
- [x] `actionlint` + YAML — workflows clean
- [x] `make integration-test` — **25/25 IT tests pass** across 11 classes (controller fixes verified)
- [x] `make static-check` — full composite quality gate green
- [ ] CI on this PR — full pipeline incl. the new `container-structure-test` step on all 4 services

## Findings explicitly addressed

**Test coverage** — 1 HIGH (e2e POST status), 4 MEDIUM (employee 404 IT, dept/org 404 product bug, org with-* missing-id, peer 5xx), 2 LOW (employee FK finders, gateway routing — see note below).

**Docker pipeline** — 1 MEDIUM Pattern B (NOT changed — see "Not changed" above), 2 LOW (container-structure-test added, tag-push cascade — already fixed in #65), 2 INFO (`.trivyignore` removal triggers, `VARIANT=debug` dead config — both addressed).

**LOW #7 (gateway routing)** — the test agent explicitly said "Acceptable, no action strictly required" because routing/path-rewrite is a manifest/config concern best covered by e2e; the new negative tests 11d/11e/11f already exercise gateway routing for the org with-* endpoints, so this is now covered as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
