### PR TITLE
fix(docker): patch base-image OS packages to clear CVE-2026-45447

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,4 +1,5 @@
 ignored:
+  - DL3005  # apt-get upgrade is the deliberate base-OS CVE-hygiene policy (see security rules); base images lag distro security rebuilds
   - DL3008  # Pin versions in apt-get install (not applicable — distroless base, no apt)
   - DL3018  # Pin versions in apk add (not applicable)
   - SC2035  # Use ./*glob* — intentional *.jar glob in layertools extract

--- a/department-service/Dockerfile
+++ b/department-service/Dockerfile
@@ -9,6 +9,12 @@ RUN java -Djarmode=tools -jar app.jar extract --layers --destination extracted
 
 FROM eclipse-temurin:25.0.3_9-jre-noble@sha256:f9bd8815e73632c22985ebb133ec49b9fc4ad5ffe0657594ac02748ad0431ab7 AS runtime
 
+# Patch base-image OS packages for security fixes that lag the base rebuild
+# (e.g. CVE-2026-45447 in libssl3t64/openssl). Runs as root before the
+# non-root USER switch. DL3005 is intentionally allowed (see .hadolint.yaml).
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd -r appuser && useradd -r -g appuser -u 10001 -d /application appuser
 USER 10001
 WORKDIR /application

--- a/employee-service/Dockerfile
+++ b/employee-service/Dockerfile
@@ -9,6 +9,12 @@ RUN java -Djarmode=tools -jar app.jar extract --layers --destination extracted
 
 FROM eclipse-temurin:25.0.3_9-jre-noble@sha256:f9bd8815e73632c22985ebb133ec49b9fc4ad5ffe0657594ac02748ad0431ab7 AS runtime
 
+# Patch base-image OS packages for security fixes that lag the base rebuild
+# (e.g. CVE-2026-45447 in libssl3t64/openssl). Runs as root before the
+# non-root USER switch. DL3005 is intentionally allowed (see .hadolint.yaml).
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd -r appuser && useradd -r -g appuser -u 10001 -d /application appuser
 USER 10001
 WORKDIR /application

--- a/gateway-service/Dockerfile
+++ b/gateway-service/Dockerfile
@@ -9,6 +9,12 @@ RUN java -Djarmode=tools -jar app.jar extract --layers --destination extracted
 
 FROM eclipse-temurin:25.0.3_9-jre-noble@sha256:f9bd8815e73632c22985ebb133ec49b9fc4ad5ffe0657594ac02748ad0431ab7 AS runtime
 
+# Patch base-image OS packages for security fixes that lag the base rebuild
+# (e.g. CVE-2026-45447 in libssl3t64/openssl). Runs as root before the
+# non-root USER switch. DL3005 is intentionally allowed (see .hadolint.yaml).
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd -r appuser && useradd -r -g appuser -u 10001 -d /application appuser
 USER 10001
 WORKDIR /application

--- a/organization-service/Dockerfile
+++ b/organization-service/Dockerfile
@@ -9,6 +9,12 @@ RUN java -Djarmode=tools -jar app.jar extract --layers --destination extracted
 
 FROM eclipse-temurin:25.0.3_9-jre-noble@sha256:f9bd8815e73632c22985ebb133ec49b9fc4ad5ffe0657594ac02748ad0431ab7 AS runtime
 
+# Patch base-image OS packages for security fixes that lag the base rebuild
+# (e.g. CVE-2026-45447 in libssl3t64/openssl). Runs as root before the
+# non-root USER switch. DL3005 is intentionally allowed (see .hadolint.yaml).
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd -r appuser && useradd -r -g appuser -u 10001 -d /application appuser
 USER 10001
 WORKDIR /application


### PR DESCRIPTION
## Root cause

`main`'s CI is red: the `image-scan` (Trivy, `CRITICAL,HIGH`) job fails on all four services with **CVE-2026-45447** (HIGH) in `libssl3t64`/`openssl` `3.0.13-0ubuntu3.9`, shipped by the `eclipse-temurin:25.0.3_9-jre-noble` base.

This is a **`main` problem, not a PR problem** — it also blocks the image-scan on PRs #84 and #86 (identical failure across PRs ⇒ diagnose `main`).

The Ubuntu noble fix (`3.0.13-0ubuntu3.11`) was published 2026-06-09; the current temurin rebuild predates it, so **no base-digest bump clears the CVE today**. The durable fix for an apt-based image whose base lags distro security rebuilds is to `apt-get upgrade` at build time.

## Fix

- Add `RUN apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*` (root, before the non-root `USER` switch) to all 4 service Dockerfiles.
- Allow hadolint **DL3005** in `.hadolint.yaml` — `apt-get upgrade` is the deliberate base-OS CVE-hygiene policy.

## Verification (local)

- `hadolint` clean on all 4 Dockerfiles.
- Department image `libssl3t64`: `3.0.13-0ubuntu3.9` → **`3.0.13-0ubuntu3.11`**.
- `trivy image --severity CRITICAL,HIGH --exit-code 1 department:scan` → **exit 0** (was 1, 2 HIGH).

## Impact

Makes `main` green and unblocks the image-scan gate for the open Renovate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)