### PR TITLE
docs: drop "Runnable" from the README title and About one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/spring-microservices-k8s)
 
-# Runnable Spring Boot 4 Microservices on Kind
+# Spring Boot 4 Microservices on Kind
 
 Reference implementation of four Spring Boot 4 microservices — gateway, organization, department, employee — deployed to a local Kind cluster in one command, with Spring Cloud Kubernetes cross-namespace service discovery.
 


### PR DESCRIPTION
Per maintainer feedback — the "Runnable" adjective added little; the description already conveys the one-command end-to-end story. Aligns the README H1 and the GitHub About on **Spring Boot 4 Microservices on Kind**.

README-only change; the GitHub About one-liner is updated separately via `gh repo edit`.