### PR TITLE
fix(ci): require image-scan SUCCESS to publish, not merely absence of failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,7 +546,25 @@ jobs:
         run: make e2e
 
   docker:
-    if: ${{ !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/') }}
+    # `!failure()` alone is NOT enough to gate a release on a scan: a SKIPPED job
+    # satisfies it. `image-scan` happens to always run on a tag today (the `changes`
+    # job forces code=true for tags), but that is a guarantee living in a DIFFERENT
+    # job's `if:` — one edit there and this publishes unscanned images, silently.
+    # Require the blocking prerequisites to have actually SUCCEEDED, per the
+    # /ci-workflow rule learned by cutting real tags twice (activemq-ldap 2026-06-30):
+    # check the DIRECT need's result explicitly rather than relying on a status
+    # function that cannot distinguish "passed" from "never ran".
+    #
+    # cve-check is deliberately NOT in the success list — it is advisory (every step
+    # is continue-on-error) and must never be able to veto a release by being slow or
+    # skipped. `!failure()` still blocks it from failing the release for a REAL reason
+    # (e.g. `make maven-settings-ossindex`, which has no continue-on-error).
+    if: >-
+      ${{ !cancelled() && !failure()
+      && needs.build.result == 'success'
+      && needs.test.result == 'success'
+      && needs.image-scan.result == 'success'
+      && startsWith(github.ref, 'refs/tags/') }}
     # Gate releases on the full pre-push hardening pipeline:
     #   build + test + cve-check + image-scan (Trivy CRITICAL/HIGH + Spring Boot smoke
     #   test + container-structure-test) → push (Pattern A, no in-manifest attestations)


### PR DESCRIPTION
fix(ci): require image-scan SUCCESS to publish, not merely absence of failure

The previous commit added image-scan to docker's needs: so a CRITICAL
finding blocks the release. That was necessary but not sufficient:
docker's `if:` was `!failure() && !cancelled()`, and a SKIPPED job
satisfies `!failure()`. The gate therefore could not distinguish "the
scan passed" from "the scan never ran".

It holds today only because image-scan always runs on a tag — the
changes job forces code=true for tags. But that is a guarantee living in
a DIFFERENT job's `if:`. One edit there and this publishes and
cosign-signs unscanned images, silently, with a green run.

Now gated on the direct needs' actual results, per the /ci-workflow rule
learned by cutting real tags twice (activemq-ldap 2026-06-30): check
needs.<job>.result == 'success' explicitly rather than relying on a
status function that cannot tell "passed" from "never ran".

cve-check is deliberately excluded from the success list. It is advisory
(every step is continue-on-error) and must never veto a release by being
slow or skipped — that was the point of the step-level timeout added
earlier. `!failure()` still blocks it from failing the release for a REAL
reason, e.g. `make maven-settings-ossindex`, which has no
continue-on-error.

Found by auditing this session's own work against the repo's own
documented CI conventions — the rule already existed and I had not
applied it to this `if:`.

actionlint clean (it validates the hyphenated needs.image-scan.result
reference).
