### PR TITLE
fix(make): make the trivy-fs floor non-env-overridable, and report jq in deps-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ deps-install: deps
 #deps-check: @ Show required tools and installation status
 deps-check:
 	@echo "--- Tool status ---"
-	@for tool in java mvn docker kubectl kind act hadolint gitleaks trivy actionlint shellcheck node; do \
+	@for tool in java mvn docker kubectl kind act hadolint gitleaks trivy actionlint shellcheck node jq; do \
 		printf "  %-16s " "$$tool:"; \
 		command -v $$tool >/dev/null 2>&1 && echo "installed" || echo "NOT installed"; \
 	done
@@ -261,7 +261,14 @@ secrets: deps
 # moves the count by tens, not hundreds) and 12x above the degraded signature.
 # Re-measure after any large dependency change with:
 #   trivy fs --scanners vuln --list-all-pkgs -f json . | jq '[.Results[].Packages//[]]|flatten|length'
-TRIVY_FS_MIN_PACKAGES ?= 900
+# `:=` NOT `?=` — deliberate. `?=` lets the ENVIRONMENT set this, so a stray
+# `export TRIVY_FS_MIN_PACKAGES=1` would silently disable a security floor while the
+# gate still printed a pass (verified: `TRIVY_FS_MIN_PACKAGES=1 make -pn` resolved it
+# to 1 under `?=`). This is not an operator knob — the recipe below explicitly says
+# not to lower it. `:=` keeps the env out while STILL allowing an explicit
+# command-line override (`make trivy-fs TRIVY_FS_MIN_PACKAGES=2000`), which is how the
+# floor's RED is proven; Make gives command-line assignments precedence over `:=`.
+TRIVY_FS_MIN_PACKAGES := 900
 
 #trivy-fs: @ Scan filesystem for vulnerabilities, secrets, and misconfigurations
 # --offline-scan: never contact Maven Central. Resolving parent/BOM POMs at scan time


### PR DESCRIPTION
fix(make): make the trivy-fs floor non-env-overridable, and report jq in deps-check

Two gaps in my own earlier change, found by auditing it rather than
re-running the same sweeps.

1. TRIVY_FS_MIN_PACKAGES used `?=`, which lets the ENVIRONMENT set it.
   A stray `export TRIVY_FS_MIN_PACKAGES=1` therefore silently disabled a
   security floor while the gate still printed a pass — verified:
   `TRIVY_FS_MIN_PACKAGES=1 make -pn` resolved it to 1. That directly
   contradicts the recipe's own error text, which says not to lower it to
   get green. It is not an operator knob.

   Switched to `:=`. Verified in a throwaway Makefile and then on the real
   one that this blocks the environment while STILL allowing an explicit
   command-line override (`make trivy-fs TRIVY_FS_MIN_PACKAGES=2000`) —
   Make gives command-line assignments precedence over `:=`. That matters
   because the command-line form is how the floor's RED is proven, so a
   blunt `override` or a hardcoded literal would have cost the RED-proof.

   RED-proven both directions after the change: env var leaves it at 900;
   command-line 2000 still fails the gate (rc=2, "only 1127 packages");
   the normal run is still green at 1127.

2. jq was declared in .mise.toml but missing from deps-check's tool list,
   so the tool-status report omitted a tool the trivy-fs gate now needs.
   Added; `make deps-check` now reports it installed, rc=0.

No behaviour change to the scan itself.
