### PR TITLE
fix(make): trivy-fs findings branch printed no table — trivy convert has no --severity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ trivy-fs: deps
 		exit 1; \
 	fi; \
 	if [ "$$finds" -gt 0 ]; then \
-		trivy convert --format table --severity CRITICAL,HIGH "$$out"; \
+		trivy convert --format table --scanners vuln,secret,misconfig "$$out"; \
 		echo "ERROR: $$finds CRITICAL/HIGH finding(s) - see the table above."; \
 		exit 1; \
 	fi


### PR DESCRIPTION
fix(make): trivy-fs findings branch printed NO table — `trivy convert` has no --severity

The findings branch of `trivy-fs` had never executed, because the repo
currently has 0 CRITICAL/HIGH findings. Forcing it to run exposed that it
was broken.

`trivy convert` accepts --format and --exit-code but NOT --severity
(verified against `trivy convert --help`, trivy 0.72.0). The shipped form
did not error — it exited 0 and printed:

  WARN [report] No enabled scanners found. Summary table will not be displayed.

so the operator would have seen "ERROR: N CRITICAL/HIGH finding(s) - see
the table above" with NO TABLE ABOVE. It would have fired for the first
time on the day a real CVE landed, and looked like a broken gate rather
than a finding.

--severity was also redundant: the JSON is already severity-filtered at
scan time, which is presumably why it went unnoticed.

Fixed to `--format table --scanners vuln,secret,misconfig`. The
--scanners flag is what suppresses the warning and renders the summary
table ("Used only for rendering the summary table", per its own help).

RED-proven end-to-end, not just as a bare command: temporarily widened
the scan severity to include MEDIUM so the branch actually fired ->
rc=2, 66 table lines rendered, the error line printed, real CVE detail
visible (jackson-databind CVE-2026-54515). Restored from a file copy
(not `git checkout --`, which would have eaten the uncommitted fix) and
re-verified green: 1127 packages, 0 findings, rc=0.

Also verified in the same pass, since it was the other path I had built
but never run: the CI cache-miss seed step's `mvn -B -q
dependency:go-offline` exits 0.
